### PR TITLE
Fix missing colon when resolving full url

### DIFF
--- a/src/cloudscribe.Web.SiteMap/Controllers/SiteMapController.cs
+++ b/src/cloudscribe.Web.SiteMap/Controllers/SiteMapController.cs
@@ -92,7 +92,7 @@ namespace cloudscribe.Web.SiteMap.Controllers
             if (isFull) return providedUrl;
             if(providedUrl.StartsWith("/"))
             {
-                return $"{Request.Scheme}//{Request.Host}{providedUrl}";
+                return $"{Request.Scheme}://{Request.Host}{providedUrl}";
             }
             // unexpected format, just return the provided url
             return providedUrl;


### PR DESCRIPTION
I realised when using relative urls to generate the sitemap they were coming out as https// instead of https://