### PR TITLE
Add xsd schema file

### DIFF
--- a/cloudscribe.Web.Navigation.sln
+++ b/cloudscribe.Web.Navigation.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.4
+VisualStudioVersion = 15.0.27130.2010
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{00C77D27-B3F9-4926-AB54-EA90E1BD8BE9}"
 EndProject
@@ -55,5 +55,8 @@ Global
 		{FB123B3E-8722-4306-A9EF-0A30F35C888B} = {00C77D27-B3F9-4926-AB54-EA90E1BD8BE9}
 		{6469BF63-2F34-496D-9F9E-82E7552C2FCB} = {00C77D27-B3F9-4926-AB54-EA90E1BD8BE9}
 		{08628955-9A34-4134-BD3B-5F84FF6C48E5} = {0B287AC2-2966-4FC0-A510-B61ADA861DA6}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {6282B617-B1AF-4162-84F7-B4B582DAFBCA}
 	EndGlobalSection
 EndGlobal

--- a/src/cloudscribe.Web.Navigation/CloudscribeNavigation.xsd
+++ b/src/cloudscribe.Web.Navigation/CloudscribeNavigation.xsd
@@ -14,7 +14,7 @@
         <xs:element ref="Children"/>
         <xs:element ref="DataAttributes" minOccurs="0"/>
       </xs:sequence>
-      <xs:attribute name="key" type="xs:string" use="optional" />
+      <xs:attribute name="key" type="xs:string" use="required" />
       <xs:attribute name="controller" type="xs:string" use="optional" />
       <xs:attribute name="action" type="xs:string" use="optional" />
       <xs:attribute name="area" type="xs:string" use="optional" />
@@ -28,9 +28,9 @@
       <xs:attribute name="viewRoles" type="xs:string" use="optional" />
       <xs:attribute name="customData" type="xs:string" use="optional" />
       <xs:attribute name="isRootNode" type="xs:boolean" use="optional" />
-      <xs:attribute name="hideFromAuthenticated" type="xs:boolean" use="optional" />
-      <xs:attribute name="hideFromAnonymous" type="xs:boolean" use="optional" />
-      <xs:attribute name="isClickable" type="xs:boolean" use="optional" />
+      <xs:attribute name="hideFromAuthenticated" type="xs:boolean" use="optional" default="false" />
+      <xs:attribute name="hideFromAnonymous" type="xs:boolean" use="optional" default="false" />
+      <xs:attribute name="isClickable" type="xs:boolean" use="optional" default="true" />
       <xs:attribute name="iconCssClass" type="xs:string" use="optional" />
       <xs:attribute name="cssClass" type="xs:string" use="optional" />
     </xs:complexType>

--- a/src/cloudscribe.Web.Navigation/CloudscribeNavigation.xsd
+++ b/src/cloudscribe.Web.Navigation/CloudscribeNavigation.xsd
@@ -1,0 +1,55 @@
+<xs:schema attributeFormDefault="unqualified" 
+           elementFormDefault="qualified" 
+           xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="Children">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element ref="NavNode" maxOccurs="unbounded" minOccurs="0"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="NavNode">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="Children"/>
+        <xs:element ref="DataAttributes" minOccurs="0"/>
+      </xs:sequence>
+      <xs:attribute name="key" type="xs:string" use="optional" />
+      <xs:attribute name="controller" type="xs:string" use="optional" />
+      <xs:attribute name="action" type="xs:string" use="optional" />
+      <xs:attribute name="area" type="xs:string" use="optional" />
+      <xs:attribute name="namedRoute" type="xs:string" use="optional" />
+      <xs:attribute name="text" type="xs:string" use="optional" />
+      <xs:attribute name="title" type="xs:string" use="optional" />
+      <xs:attribute name="url" type="xs:anyURI" use="optional" />
+      <xs:attribute name="preservedRouteParameters" type="xs:string" use="optional" />
+      <xs:attribute name="componentVisibility" type="xs:string" use="optional" />
+      <xs:attribute name="authorizationPolicy" type="xs:string" use="optional" />
+      <xs:attribute name="viewRoles" type="xs:string" use="optional" />
+      <xs:attribute name="customData" type="xs:string" use="optional" />
+      <xs:attribute name="isRootNode" type="xs:boolean" use="optional" />
+      <xs:attribute name="hideFromAuthenticated" type="xs:boolean" use="optional" />
+      <xs:attribute name="hideFromAnonymous" type="xs:boolean" use="optional" />
+      <xs:attribute name="isClickable" type="xs:boolean" use="optional" />
+      <xs:attribute name="iconCssClass" type="xs:string" use="optional" />
+      <xs:attribute name="cssClass" type="xs:string" use="optional" />
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="DataAttribute">
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:string">
+          <xs:attribute type="xs:string" name="attribute" use="optional"/>
+          <xs:attribute type="xs:string" name="value" use="optional"/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="DataAttributes">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="DataAttribute" maxOccurs="unbounded" minOccurs="0"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/src/cloudscribe.Web.Navigation/CloudscribeNavigation.xsd
+++ b/src/cloudscribe.Web.Navigation/CloudscribeNavigation.xsd
@@ -11,8 +11,8 @@
   <xs:element name="NavNode">
     <xs:complexType>
       <xs:sequence>
-        <xs:element ref="Children"/>
-        <xs:element ref="DataAttributes" minOccurs="0"/>
+        <xs:element ref="Children" minOccurs="1" maxOccurs="1"/>
+        <xs:element ref="DataAttributes" minOccurs="0" maxOccurs="1"/>
       </xs:sequence>
       <xs:attribute name="key" type="xs:string" use="required" />
       <xs:attribute name="controller" type="xs:string" use="optional" />

--- a/src/cloudscribe.Web.Navigation/CloudscribeNavigation.xsd
+++ b/src/cloudscribe.Web.Navigation/CloudscribeNavigation.xsd
@@ -39,8 +39,8 @@
     <xs:complexType>
       <xs:simpleContent>
         <xs:extension base="xs:string">
-          <xs:attribute type="xs:string" name="attribute" use="optional"/>
-          <xs:attribute type="xs:string" name="value" use="optional"/>
+          <xs:attribute type="xs:string" name="attribute" use="required" />
+          <xs:attribute type="xs:string" name="value" use="required" />
         </xs:extension>
       </xs:simpleContent>
     </xs:complexType>


### PR DESCRIPTION
Allows quicker creation of xml navigation maps when working with tools like visual studio.

Would require you being willing to host the xsd file from your cloudscribe domain, but as it would be hit only by developers, server loads would hopefully be acceptable.