### PR TITLE
Update version to 8.8

### DIFF
--- a/src/NavigationDemo.Web/NavigationDemo.Web.csproj
+++ b/src/NavigationDemo.Web/NavigationDemo.Web.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="cloudscribe.Web.Localization" Version="8.7.0" />
+    <PackageReference Include="cloudscribe.Web.Localization" Version="8.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/cloudscribe.Web.Navigation/cloudscribe.Web.Navigation.csproj
+++ b/src/cloudscribe.Web.Navigation/cloudscribe.Web.Navigation.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>an ASP.NET Core viewcomponent for menus and breadcrumbs</Description>
-    <Version>8.7.0</Version>
+    <Version>8.8.0</Version>
     <TargetFramework>net8.0</TargetFramework>
     <Authors>Joe Audette</Authors>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>

--- a/src/cloudscribe.Web.SiteMap.FromNavigation/cloudscribe.Web.SiteMap.FromNavigation.csproj
+++ b/src/cloudscribe.Web.SiteMap.FromNavigation/cloudscribe.Web.SiteMap.FromNavigation.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>cloudscribe.Web.SiteMap.FromNavigation a library that implements ISiteMapNodeService using existing tree of nodes from cloudscribe.Web.Navigation.NavigationTreeBuilderService</Description>
-    <Version>8.7.0</Version>
+    <Version>8.8.0</Version>
     <TargetFramework>net8.0</TargetFramework>
     <Authors>Joe Audette</Authors>
     <PackageTags>cloudscribe;mvc;sitemap</PackageTags>

--- a/src/cloudscribe.Web.SiteMap/cloudscribe.Web.SiteMap.csproj
+++ b/src/cloudscribe.Web.SiteMap/cloudscribe.Web.SiteMap.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core controller and models for generating an xml sitemap for search indexes http://www.sitemaps.org</Description>
-    <Version>8.7.0</Version>
+    <Version>8.8.0</Version>
     <TargetFramework>net8.0</TargetFramework>
 
     <Authors>Joe Audette</Authors>

--- a/update_version.ps1
+++ b/update_version.ps1
@@ -16,9 +16,9 @@
 $directory = "src"
 
 # Define the old & new versions
-$oldVersion = '8\.6'   # slash needed !
-$newVersion = "8.7.0"
-$newWildcardVersion = "8.7.*"
+$oldVersion = '8\.7'   # slash needed !
+$newVersion = "8.8.0"
+$newWildcardVersion = "8.8.*"
 	
 
 # Get all .csproj files in the directory and subdirectories


### PR DESCRIPTION
## Summary
- Updated version from 8.7 to 8.8.0 in all project files
- Updated PowerShell version script with new version numbers
- Built successfully

## Files Affected
- update_version.ps1
- src/cloudscribe.Web.Navigation/cloudscribe.Web.Navigation.csproj
- src/cloudscribe.Web.SiteMap/cloudscribe.Web.SiteMap.csproj
- src/cloudscribe.Web.SiteMap.FromNavigation/cloudscribe.Web.SiteMap.FromNavigation.csproj
- src/NavigationDemo.Web/NavigationDemo.Web.csproj

## Test plan
- [x] PowerShell version script executed successfully
- [x] Solution builds without errors
- [x] All package references updated correctly

🤖 Generated with [Claude Code](https://claude.ai/code)